### PR TITLE
Initalize a basic server for commit logs

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/acikgozb/proglog/internal/server"
+	"log"
+)
+
+func main() {
+	srv := server.NewHttpServer(":8080")
+	log.Fatal(srv.ListenAndServe())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/acikgozb/proglog
 
 go 1.21.4
+
+require github.com/go-chi/chi/v5 v5.0.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.0.11 h1:BnpYbFZ3T3S1WMpD79r7R5ThWX40TaFB7L31Y8xqSwA=
+github.com/go-chi/chi/v5 v5.0.11/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/go-chi/chi/v5"
+	"net/http"
+)
+
+type httpServer struct {
+	Log *Log
+}
+
+type ProduceRequest struct {
+	Record Record `json:"record"`
+}
+
+type ProduceResponse struct {
+	Offset uint64 `json:"offset"`
+}
+
+type ConsumeRequest struct {
+	Offset uint64 `json:"offset"`
+}
+
+type ConsumeResponse struct {
+	Record Record `json:"record"`
+}
+
+func NewHttpServer(addr string) *http.Server {
+	server := newHTTPServer()
+	router := chi.NewRouter()
+
+	router.Post("/", server.handleProduce)
+	router.Get("/", server.handleConsume)
+
+	return &http.Server{
+		Addr:    addr,
+		Handler: router,
+	}
+}
+
+func newHTTPServer() *httpServer {
+	return &httpServer{
+		Log: NewLog(),
+	}
+}
+
+func (server *httpServer) handleProduce(w http.ResponseWriter, r *http.Request) {
+	var req ProduceRequest
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	offset, appendErr := server.Log.Append(req.Record)
+	if appendErr != nil {
+		http.Error(w, appendErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	response := ProduceResponse{
+		Offset: offset,
+	}
+	encodeError := json.NewEncoder(w).Encode(&response)
+	if encodeError != nil {
+		http.Error(w, appendErr.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (server *httpServer) handleConsume(w http.ResponseWriter, r *http.Request) {
+	var request ConsumeRequest
+	parseErr := json.NewDecoder(r.Body).Decode(&request)
+	if parseErr != nil {
+		http.Error(w, parseErr.Error(), http.StatusBadRequest)
+		return
+	}
+
+	record, readErr := server.Log.Read(request.Offset)
+	if errors.Is(readErr, ErrOffsetNotFound) {
+		http.Error(w, readErr.Error(), http.StatusNotFound)
+		return
+	}
+
+	if readErr != nil {
+		http.Error(w, readErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	consumeResponse := ConsumeResponse{Record: record}
+	encodeErr := json.NewEncoder(w).Encode(consumeResponse)
+	if encodeErr != nil {
+		http.Error(w, encodeErr.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Log struct {
+	mu      sync.Mutex
+	records []Record
+}
+
+type Record struct {
+	Offset uint64
+	Value  []byte
+}
+
+func NewLog() *Log {
+	return &Log{}
+}
+
+func (log *Log) Append(record Record) (uint64, error) {
+	log.mu.Lock()
+	defer log.mu.Unlock()
+
+	record.Offset = uint64(len(log.records))
+	log.records = append(log.records, record)
+
+	return record.Offset, nil
+}
+
+func (log *Log) Read(offset uint64) (Record, error) {
+	log.mu.Lock()
+	defer log.mu.Unlock()
+
+	if offset >= uint64(len(log.records)) {
+		return Record{}, ErrOffsetNotFound
+	}
+
+	return log.records[offset], nil
+}
+
+var ErrOffsetNotFound = fmt.Errorf("offset not found")


### PR DESCRIPTION
- The entrypoint is created under cmd/server directory to initialize our server and run it on port `8080`.
- `go-chi` is used to implement a basic router.
- Currently, there are 2 endpoints and handlers, one of reading the logs and another one to add a new log, called `handleConsume` and `handleProduce` respectively.
- Necessary structs for request and response models are added as well.
- A new package called `server` is implemented to contain our main business logic, which is keeping a `commit log`. For this, a `Log` struct and necessary methods to read and write this struct are written.